### PR TITLE
refactor:Memory优化

### DIFF
--- a/CodeBase-Memory/pom.xml
+++ b/CodeBase-Memory/pom.xml
@@ -51,6 +51,17 @@
 			<artifactId>spring-ai-advisors-vector-store</artifactId>
 		</dependency>
 
+		<!-- Spring Kafka -->
+		<dependency>
+			<groupId>org.springframework.kafka</groupId>
+			<artifactId>spring-kafka</artifactId>
+		</dependency>
+		<!-- Kafka Clients -->
+		<dependency>
+			<groupId>org.apache.kafka</groupId>
+			<artifactId>kafka-clients</artifactId>
+		</dependency>
+
 		<dependency>
 			<groupId>com.fasterxml.jackson.datatype</groupId>
 			<artifactId>jackson-datatype-jsr310</artifactId>

--- a/CodeBase-Memory/server/requirements.txt
+++ b/CodeBase-Memory/server/requirements.txt
@@ -4,3 +4,5 @@ pydantic==2.10.4
 mem0ai>=0.1.115
 python-dotenv==1.0.1
 psycopg2-binary==2.9.10
+langchain_neo4j
+rank_bm25

--- a/CodeBase-Memory/src/main/java/com/hxg/memory/queue/config/KafkaConfig.java
+++ b/CodeBase-Memory/src/main/java/com/hxg/memory/queue/config/KafkaConfig.java
@@ -1,0 +1,60 @@
+package com.hxg.memory.queue.config;
+
+import com.hxg.memory.queue.model.MemoryIndexTask;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.listener.ContainerProperties;
+import org.springframework.kafka.support.serializer.JsonDeserializer;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Configuration
+@EnableKafka
+public class KafkaConfig {
+
+    @Value("${spring.kafka.bootstrap-servers}")
+    private String bootstrapServers;
+
+    @Value("${spring.kafka.consumer.group-id}")
+    private String groupId;
+
+    @Value("${project.memory.kafka.consumer.max-concurrency}")
+    private int maxConcurrency;
+
+    @Bean
+    public ConsumerFactory<String, MemoryIndexTask> consumerFactory() {
+        Map<String, Object> props = new HashMap<>();
+        props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        props.put(ConsumerConfig.GROUP_ID_CONFIG, groupId);
+        props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class);
+        props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+        props.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, false);
+
+        props.put(JsonDeserializer.TRUSTED_PACKAGES, "com.hxg.memory.queue.model,com.hxg.queue.model");
+        props.put(JsonDeserializer.VALUE_DEFAULT_TYPE, MemoryIndexTask.class.getName());
+        props.put(JsonDeserializer.USE_TYPE_INFO_HEADERS, false);
+
+        return new DefaultKafkaConsumerFactory<>(props, new StringDeserializer(),
+                new JsonDeserializer<>(MemoryIndexTask.class));
+    }
+
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, MemoryIndexTask> kafkaListenerContainerFactory() {
+        ConcurrentKafkaListenerContainerFactory<String, MemoryIndexTask> factory = new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(consumerFactory());
+        factory.setConcurrency(maxConcurrency);
+        factory.getContainerProperties().setAckMode(ContainerProperties.AckMode.MANUAL_IMMEDIATE);
+        return factory;
+    }
+}
+
+

--- a/CodeBase-Memory/src/main/java/com/hxg/memory/queue/consumer/MemoryIndexConsumer.java
+++ b/CodeBase-Memory/src/main/java/com/hxg/memory/queue/consumer/MemoryIndexConsumer.java
@@ -1,0 +1,147 @@
+package com.hxg.memory.queue.consumer;
+
+import com.hxg.memory.queue.model.MemoryIndexTask;
+import com.hxg.memory.queue.producer.MemoryIndexProducer;
+import com.hxg.memory.service.DocumentMemoryService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.kafka.support.KafkaHeaders;
+import org.springframework.messaging.handler.annotation.Header;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.stereotype.Component;
+
+import java.util.Objects;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
+
+@Component
+public class MemoryIndexConsumer {
+
+    private static final Logger log = LoggerFactory.getLogger(MemoryIndexConsumer.class);
+
+    private final DocumentMemoryService documentMemoryService;
+    private final MemoryIndexProducer producer;
+    private final Semaphore concurrencyLimiter;
+
+    @Value("${project.memory.kafka.consumer.max-concurrency}")
+    private int maxConcurrency;
+
+    @Value("${project.memory.kafka.consumer.process-interval}")
+    private long processIntervalMs;
+
+    @Value("${project.memory.kafka.consumer.max-retry}")
+    private int maxRetry;
+
+    public MemoryIndexConsumer(DocumentMemoryService documentMemoryService, MemoryIndexProducer producer) {
+        this.documentMemoryService = documentMemoryService;
+        this.producer = producer;
+        this.concurrencyLimiter = new Semaphore(2);
+    }
+
+    @KafkaListener(topics = "${project.memory.kafka.topics.mem-index}")
+    public void consumeMain(@Payload MemoryIndexTask task,
+                            @Header(KafkaHeaders.RECEIVED_TOPIC) String topic,
+                            @Header(KafkaHeaders.RECEIVED_PARTITION) int partition,
+                            @Header(KafkaHeaders.OFFSET) long offset,
+                            Acknowledgment ack) {
+        log.info("接收到索引任务: type={}, repo={}, topic={}, partition={}, offset={}",
+                task.getType(), task.getRepositoryId(), topic, partition, offset);
+
+        processTask(task, ack, false);
+    }
+
+    @KafkaListener(topics = "${project.memory.kafka.topics.mem-retry}")
+    public void consumeRetry(@Payload MemoryIndexTask task,
+                             @Header(KafkaHeaders.RECEIVED_TOPIC) String topic,
+                             @Header(KafkaHeaders.RECEIVED_PARTITION) int partition,
+                             @Header(KafkaHeaders.OFFSET) long offset,
+                             Acknowledgment ack) {
+        log.info("接收到重试索引任务: type={}, repo={}, retryCount={}, topic={}, partition={}, offset={}",
+                task.getType(), task.getRepositoryId(), task.getRetryCount(), topic, partition, offset);
+
+        // 简单延迟，避免紧急重试
+        try {
+            Thread.sleep(Math.max(processIntervalMs, 1000));
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+
+        processTask(task, ack, true);
+    }
+
+    private void processTask(MemoryIndexTask task, Acknowledgment ack, boolean isRetry) {
+        boolean acquired = false;
+        try {
+            acquired = concurrencyLimiter.tryAcquire(10, TimeUnit.SECONDS);
+            if (!acquired) {
+                log.warn("无法获取并发许可，跳过任务: repo={}, type={}", task.getRepositoryId(), task.getType());
+                return; // 不ack，等待重新投递
+            }
+
+            if (processIntervalMs > 0) {
+                Thread.sleep(processIntervalMs);
+            }
+
+            validate(task);
+
+            switch (task.getType()) {
+                case "document" -> documentMemoryService
+                        .addDocumentMemoryAsync(task.getRepositoryId(), task.getDocumentName(),
+                                task.getDocumentContent(), task.getDocumentUrl(), task.getMetadata())
+                        .join();
+                case "code_file" -> documentMemoryService
+                        .addCodeFileMemoryAsync(task.getRepositoryId(), task.getFileName(), task.getFilePath(),
+                                task.getFileContent(), task.getFileType())
+                        .join();
+                default -> throw new IllegalArgumentException("未知的任务类型: " + task.getType());
+            }
+
+            ack.acknowledge();
+            log.info("索引任务完成: type={}, repo={}", task.getType(), task.getRepositoryId());
+        } catch (Exception e) {
+            log.error("索引任务失败: type={}, repo={}, error={}", task.getType(), task.getRepositoryId(), e.getMessage(), e);
+            handleFailure(task, e, isRetry);
+            ack.acknowledge();
+        } finally {
+            if (acquired) {
+                concurrencyLimiter.release();
+            }
+        }
+    }
+
+    private void validate(MemoryIndexTask task) {
+        if (task == null) throw new IllegalArgumentException("任务为空");
+        if (task.getType() == null) throw new IllegalArgumentException("任务类型为空");
+        if (!Objects.equals(task.getType(), "document") && !Objects.equals(task.getType(), "code_file"))
+            throw new IllegalArgumentException("非法任务类型: " + task.getType());
+        if (task.getRepositoryId() == null || task.getRepositoryId().isEmpty())
+            throw new IllegalArgumentException("repositoryId 不能为空");
+
+        if (Objects.equals(task.getType(), "document")) {
+            if (task.getDocumentName() == null || task.getDocumentContent() == null)
+                throw new IllegalArgumentException("文档任务参数不完整");
+        } else {
+            if (task.getFileName() == null || task.getFileContent() == null)
+                throw new IllegalArgumentException("代码文件任务参数不完整");
+        }
+    }
+
+    private void handleFailure(MemoryIndexTask task, Exception error, boolean isRetry) {
+        Integer retry = task.getRetryCount() == null ? 0 : task.getRetryCount();
+        retry++;
+        task.setRetryCount(retry);
+
+        if (retry > maxRetry) {
+            log.warn("任务超过最大重试次数，进入DLQ: repo={}, type={}, retryCount={}", task.getRepositoryId(), task.getType(), retry);
+            producer.sendToDlq(task, error);
+        } else {
+            log.info("任务失败，发送到重试队列: repo={}, type={}, retryCount={}", task.getRepositoryId(), task.getType(), retry);
+            producer.sendToRetry(task);
+        }
+    }
+}
+
+

--- a/CodeBase-Memory/src/main/java/com/hxg/memory/queue/model/MemoryIndexTask.java
+++ b/CodeBase-Memory/src/main/java/com/hxg/memory/queue/model/MemoryIndexTask.java
@@ -1,0 +1,136 @@
+package com.hxg.memory.queue.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import java.util.Map;
+
+/**
+ * Memory 索引任务模型
+ * 用于通过 Kafka 在 Wiki → Memory 之间传递索引任务
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class MemoryIndexTask {
+
+    /**
+     * 任务类型: document | code_file
+     */
+    private String type;
+
+    private String repositoryId;
+
+    // document fields
+    private String documentName;
+    private String documentContent;
+    private String documentUrl;
+    private Map<String, Object> metadata;
+
+    // code file fields
+    private String fileName;
+    private String filePath;
+    private String fileContent;
+    private String fileType;
+
+    // retry control
+    private Integer retryCount;
+
+    // optional tracking
+    private String taskId;
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public String getRepositoryId() {
+        return repositoryId;
+    }
+
+    public void setRepositoryId(String repositoryId) {
+        this.repositoryId = repositoryId;
+    }
+
+    public String getDocumentName() {
+        return documentName;
+    }
+
+    public void setDocumentName(String documentName) {
+        this.documentName = documentName;
+    }
+
+    public String getDocumentContent() {
+        return documentContent;
+    }
+
+    public void setDocumentContent(String documentContent) {
+        this.documentContent = documentContent;
+    }
+
+    public String getDocumentUrl() {
+        return documentUrl;
+    }
+
+    public void setDocumentUrl(String documentUrl) {
+        this.documentUrl = documentUrl;
+    }
+
+    public Map<String, Object> getMetadata() {
+        return metadata;
+    }
+
+    public void setMetadata(Map<String, Object> metadata) {
+        this.metadata = metadata;
+    }
+
+    public String getFileName() {
+        return fileName;
+    }
+
+    public void setFileName(String fileName) {
+        this.fileName = fileName;
+    }
+
+    public String getFilePath() {
+        return filePath;
+    }
+
+    public void setFilePath(String filePath) {
+        this.filePath = filePath;
+    }
+
+    public String getFileContent() {
+        return fileContent;
+    }
+
+    public void setFileContent(String fileContent) {
+        this.fileContent = fileContent;
+    }
+
+    public String getFileType() {
+        return fileType;
+    }
+
+    public void setFileType(String fileType) {
+        this.fileType = fileType;
+    }
+
+    public Integer getRetryCount() {
+        return retryCount;
+    }
+
+    public void setRetryCount(Integer retryCount) {
+        this.retryCount = retryCount;
+    }
+
+    public String getTaskId() {
+        return taskId;
+    }
+
+    public void setTaskId(String taskId) {
+        this.taskId = taskId;
+    }
+}
+
+

--- a/CodeBase-Memory/src/main/java/com/hxg/memory/queue/producer/MemoryIndexProducer.java
+++ b/CodeBase-Memory/src/main/java/com/hxg/memory/queue/producer/MemoryIndexProducer.java
@@ -1,0 +1,70 @@
+package com.hxg.memory.queue.producer;
+
+import com.hxg.memory.queue.model.MemoryIndexTask;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.SendResult;
+import org.springframework.stereotype.Service;
+
+import java.util.concurrent.CompletableFuture;
+
+@Service
+public class MemoryIndexProducer {
+
+    private static final Logger log = LoggerFactory.getLogger(MemoryIndexProducer.class);
+
+    private final KafkaTemplate<String, MemoryIndexTask> kafkaTemplate;
+
+    @Value("${project.memory.kafka.topics.mem-retry}")
+    private String retryTopic;
+
+    @Value("${project.memory.kafka.topics.mem-dlq}")
+    private String dlqTopic;
+
+    public MemoryIndexProducer(KafkaTemplate<String, MemoryIndexTask> kafkaTemplate) {
+        this.kafkaTemplate = kafkaTemplate;
+    }
+
+    public void sendToRetry(MemoryIndexTask task) {
+        try {
+            CompletableFuture<SendResult<String, MemoryIndexTask>> future =
+                kafkaTemplate.send(retryTopic, buildKey(task), task);
+            future.whenComplete((result, throwable) -> {
+                if (throwable == null) {
+                    log.info("重试消息已发送: key={}, offset={}", buildKey(task), result.getRecordMetadata().offset());
+                } else {
+                    log.error("发送重试消息失败: key={}", buildKey(task), throwable);
+                }
+            });
+        } catch (Exception e) {
+            log.error("发送到重试队列失败: key={}", buildKey(task), e);
+        }
+    }
+
+    public void sendToDlq(MemoryIndexTask task, Exception error) {
+        try {
+            CompletableFuture<SendResult<String, MemoryIndexTask>> future =
+                kafkaTemplate.send(dlqTopic, buildKey(task), task);
+            future.whenComplete((result, throwable) -> {
+                if (throwable == null) {
+                    log.warn("死信消息已发送: key={}, error={}, offset={}", buildKey(task), error.getMessage(), result.getRecordMetadata().offset());
+                } else {
+                    log.error("发送死信消息失败: key={}, error={}", buildKey(task), error.getMessage(), throwable);
+                }
+            });
+        } catch (Exception e) {
+            log.error("发送到死信队列失败: key={}", buildKey(task), e);
+        }
+    }
+
+    private String buildKey(MemoryIndexTask task) {
+        if (task.getTaskId() != null) return task.getTaskId();
+        if (task.getRepositoryId() != null && task.getDocumentName() != null) return task.getRepositoryId() + ":" + task.getDocumentName();
+        if (task.getRepositoryId() != null && task.getFileName() != null) return task.getRepositoryId() + ":" + task.getFileName();
+        return String.valueOf(System.currentTimeMillis());
+    }
+}
+
+

--- a/CodeBase-Memory/src/main/resources/application.yml
+++ b/CodeBase-Memory/src/main/resources/application.yml
@@ -2,6 +2,21 @@ server:
   port: 8080
 
 spring:
+  kafka:
+    bootstrap-servers: ${KAFKA_SERVERS:localhost:9092}
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
+    consumer:
+      group-id: memory-index-consumer-group
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
+      auto-offset-reset: earliest
+      enable-auto-commit: false
+      properties:
+        spring.json.trusted.packages: "com.hxg.memory.queue.model,com.hxg.queue.model"
+        spring.json.value.default.type: com.hxg.memory.queue.model.MemoryIndexTask
+        spring.json.use.type.headers: false
   ai:
     dashscope:
       api-key: ${AI_DASHSCOPE_API_KEY}
@@ -44,3 +59,15 @@ mem0:
         api-key: ${AI_DASHSCOPE_API_KEY}
         model: text-embedding-v4
         openai-base-url: https://dashscope.aliyuncs.com/compatible-mode/v1
+
+project:
+  memory:
+    kafka:
+      topics:
+        mem-index: "memory-index-topic"
+        mem-retry: "memory-index-retry-topic"
+        mem-dlq: "memory-index-dlq"
+      consumer:
+        max-concurrency: 2
+        process-interval: 1000
+        max-retry: 3

--- a/CodeBase-Wiki/src/main/java/com/hxg/queue/config/KafkaConfig.java
+++ b/CodeBase-Wiki/src/main/java/com/hxg/queue/config/KafkaConfig.java
@@ -1,6 +1,7 @@
 package com.hxg.queue.config;
 
 import com.hxg.queue.model.DocumentGenerationTask;
+import com.hxg.queue.model.MemoryIndexTask;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.producer.ProducerConfig;
@@ -63,6 +64,33 @@ public class KafkaConfig {
     public KafkaTemplate<String, DocumentGenerationTask> kafkaTemplate() {
         KafkaTemplate<String, DocumentGenerationTask> template = new KafkaTemplate<>(producerFactory());
         log.info("KafkaTemplate created for DocumentGenerationTask");
+        return template;
+    }
+
+    /**
+     * ProducerFactory for MemoryIndexTask
+     */
+    @Bean
+    public ProducerFactory<String, MemoryIndexTask> memoryIndexProducerFactory() {
+        Map<String, Object> configProps = new HashMap<>();
+        configProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        configProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        configProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
+        configProps.put(ProducerConfig.RETRIES_CONFIG, 3);
+        configProps.put(ProducerConfig.ACKS_CONFIG, "1");
+        configProps.put(ProducerConfig.BATCH_SIZE_CONFIG, 16384);
+        configProps.put(ProducerConfig.LINGER_MS_CONFIG, 5);
+        log.info("Kafka Producer configured for MemoryIndexTask with bootstrap servers: {}", bootstrapServers);
+        return new DefaultKafkaProducerFactory<>(configProps);
+    }
+
+    /**
+     * KafkaTemplate for MemoryIndexTask
+     */
+    @Bean
+    public KafkaTemplate<String, MemoryIndexTask> memoryIndexKafkaTemplate() {
+        KafkaTemplate<String, MemoryIndexTask> template = new KafkaTemplate<>(memoryIndexProducerFactory());
+        log.info("KafkaTemplate created for MemoryIndexTask");
         return template;
     }
     

--- a/CodeBase-Wiki/src/main/java/com/hxg/queue/model/MemoryIndexTask.java
+++ b/CodeBase-Wiki/src/main/java/com/hxg/queue/model/MemoryIndexTask.java
@@ -1,0 +1,53 @@
+package com.hxg.queue.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import java.util.Map;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class MemoryIndexTask {
+    private String type; // document | code_file
+    private String repositoryId;
+
+    // document
+    private String documentName;
+    private String documentContent;
+    private String documentUrl;
+    private Map<String, Object> metadata;
+
+    // code file
+    private String fileName;
+    private String filePath;
+    private String fileContent;
+    private String fileType;
+
+    private Integer retryCount;
+    private String taskId;
+
+    public String getType() { return type; }
+    public void setType(String type) { this.type = type; }
+    public String getRepositoryId() { return repositoryId; }
+    public void setRepositoryId(String repositoryId) { this.repositoryId = repositoryId; }
+    public String getDocumentName() { return documentName; }
+    public void setDocumentName(String documentName) { this.documentName = documentName; }
+    public String getDocumentContent() { return documentContent; }
+    public void setDocumentContent(String documentContent) { this.documentContent = documentContent; }
+    public String getDocumentUrl() { return documentUrl; }
+    public void setDocumentUrl(String documentUrl) { this.documentUrl = documentUrl; }
+    public Map<String, Object> getMetadata() { return metadata; }
+    public void setMetadata(Map<String, Object> metadata) { this.metadata = metadata; }
+    public String getFileName() { return fileName; }
+    public void setFileName(String fileName) { this.fileName = fileName; }
+    public String getFilePath() { return filePath; }
+    public void setFilePath(String filePath) { this.filePath = filePath; }
+    public String getFileContent() { return fileContent; }
+    public void setFileContent(String fileContent) { this.fileContent = fileContent; }
+    public String getFileType() { return fileType; }
+    public void setFileType(String fileType) { this.fileType = fileType; }
+    public Integer getRetryCount() { return retryCount; }
+    public void setRetryCount(Integer retryCount) { this.retryCount = retryCount; }
+    public String getTaskId() { return taskId; }
+    public void setTaskId(String taskId) { this.taskId = taskId; }
+}
+
+

--- a/CodeBase-Wiki/src/main/java/com/hxg/queue/producer/MemoryIndexProducer.java
+++ b/CodeBase-Wiki/src/main/java/com/hxg/queue/producer/MemoryIndexProducer.java
@@ -1,0 +1,58 @@
+package com.hxg.queue.producer;
+
+import com.hxg.queue.model.MemoryIndexTask;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.SendResult;
+import org.springframework.stereotype.Service;
+
+import java.util.concurrent.CompletableFuture;
+
+@Service
+@Slf4j
+public class MemoryIndexProducer {
+
+    private final KafkaTemplate<String, MemoryIndexTask> kafkaTemplate;
+
+    @Value("${project.wiki.kafka.topics.mem-index}")
+    private String memIndexTopic;
+
+    public MemoryIndexProducer(KafkaTemplate<String, MemoryIndexTask> kafkaTemplate) {
+        this.kafkaTemplate = kafkaTemplate;
+    }
+
+    public void sendDocumentTask(MemoryIndexTask task) {
+        send(task);
+    }
+
+    public void sendCodeFileTask(MemoryIndexTask task) {
+        send(task);
+    }
+
+    private void send(MemoryIndexTask task) {
+        try {
+            String key = buildKey(task);
+            CompletableFuture<SendResult<String, MemoryIndexTask>> future = kafkaTemplate.send(memIndexTopic, key, task);
+            future.whenComplete((result, throwable) -> {
+                if (throwable == null) {
+                    log.info("Memory索引任务发送成功: key={}, offset={}", key, result.getRecordMetadata().offset());
+                } else {
+                    log.error("Memory索引任务发送失败: key={}", key, throwable);
+                }
+            });
+        } catch (Exception e) {
+            log.error("发送Memory索引任务到Kafka失败", e);
+            throw new RuntimeException("Failed to send memory index task", e);
+        }
+    }
+
+    private String buildKey(MemoryIndexTask task) {
+        if (task.getTaskId() != null) return task.getTaskId();
+        if (task.getRepositoryId() != null && task.getDocumentName() != null) return task.getRepositoryId() + ":" + task.getDocumentName();
+        if (task.getRepositoryId() != null && task.getFileName() != null) return task.getRepositoryId() + ":" + task.getFileName();
+        return String.valueOf(System.currentTimeMillis());
+    }
+}
+
+

--- a/CodeBase-Wiki/src/main/java/com/hxg/queue/test/KafkaMessageFlowTest.java
+++ b/CodeBase-Wiki/src/main/java/com/hxg/queue/test/KafkaMessageFlowTest.java
@@ -1,0 +1,54 @@
+package com.hxg.queue.test;
+
+import com.hxg.queue.model.DocumentGenerationTask;
+import com.hxg.queue.producer.DocumentGenerationProducer;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+
+/**
+ * @author hxg
+ * @description: Kafka消息流程测试
+ * @date 2025/8/5
+ */
+@Component
+@Slf4j
+@ConditionalOnProperty(name = "test.kafka.enabled", havingValue = "true")
+public class KafkaMessageFlowTest implements CommandLineRunner {
+    
+    private final DocumentGenerationProducer producer;
+    
+    public KafkaMessageFlowTest(DocumentGenerationProducer producer) {
+        this.producer = producer;
+    }
+    
+    @Override
+    public void run(String... args) throws Exception {
+        log.info("开始Kafka消息流程测试...");
+        
+        // 创建测试任务
+        DocumentGenerationTask testTask = new DocumentGenerationTask();
+        testTask.setTaskId("test-task-" + System.currentTimeMillis());
+        testTask.setCatalogueId("test-catalogue-001");
+        testTask.setCatalogueName("测试文档生成");
+        testTask.setPrompt("生成一个简单的测试文档");
+        testTask.setLocalPath("C:\\Code\\CodeBase-CR");
+        testTask.setFileTree("test-file-tree");
+        testTask.setRetryCount(0);
+        testTask.setCreateTime(LocalDateTime.now());
+        testTask.setPriority("HIGH");
+        
+        // 发送测试消息
+        try {
+            producer.sendTask(testTask);
+            log.info("测试消息发送成功: taskId={}", testTask.getTaskId());
+        } catch (Exception e) {
+            log.error("测试消息发送失败", e);
+        }
+        
+        log.info("Kafka消息流程测试完成");
+    }
+}

--- a/CodeBase-Wiki/src/main/resources/application.yml
+++ b/CodeBase-Wiki/src/main/resources/application.yml
@@ -121,6 +121,9 @@ project:
         doc-generation: "doc-generation-topic"
         doc-retry: "doc-generation-retry-topic"
         doc-dlq: "doc-generation-dlq"
+        mem-index: "memory-index-topic"
+        mem-retry: "memory-index-retry-topic"
+        mem-dlq: "memory-index-dlq"
       consumer:
         # 最大并发消费者数量
         max-concurrency: 2

--- a/init-kafka-topics.sh
+++ b/init-kafka-topics.sh
@@ -37,6 +37,33 @@ kafka-topics --create \
     --replication-factor 1 \
     --config retention.ms=2592000000
 
+# Create memory-index-topic
+kafka-topics --create \
+    --if-not-exists \
+    --topic memory-index-topic \
+    --bootstrap-server kafka:29092 \
+    --partitions 4 \
+    --replication-factor 1 \
+    --config retention.ms=604800000
+
+# Create memory-index-retry-topic
+kafka-topics --create \
+    --if-not-exists \
+    --topic memory-index-retry-topic \
+    --bootstrap-server kafka:29092 \
+    --partitions 2 \
+    --replication-factor 1 \
+    --config retention.ms=86400000
+
+# Create memory-index-dlq
+kafka-topics --create \
+    --if-not-exists \
+    --topic memory-index-dlq \
+    --bootstrap-server kafka:29092 \
+    --partitions 1 \
+    --replication-factor 1 \
+    --config retention.ms=2592000000
+
 echo "Topics created successfully!"
 
 # List all topics
@@ -48,3 +75,6 @@ echo "Topic details:"
 kafka-topics --bootstrap-server kafka:29092 --describe --topic doc-generation-topic
 kafka-topics --bootstrap-server kafka:29092 --describe --topic doc-generation-retry-topic
 kafka-topics --bootstrap-server kafka:29092 --describe --topic doc-generation-dlq
+kafka-topics --bootstrap-server kafka:29092 --describe --topic memory-index-topic
+kafka-topics --bootstrap-server kafka:29092 --describe --topic memory-index-retry-topic
+kafka-topics --bootstrap-server kafka:29092 --describe --topic memory-index-dlq


### PR DESCRIPTION
This pull request introduces a Kafka-based asynchronous task queue for memory indexing, enabling reliable and scalable communication between the Wiki and Memory services. It adds the necessary Kafka configuration, task model, producer, and consumer logic to support document and code file indexing tasks, including retry and dead-letter handling. Additionally, it ensures both services share a compatible `MemoryIndexTask` model for seamless serialization.

**Kafka Integration for Memory Indexing**

* Added Kafka dependencies and configuration for both producer and consumer in the Memory service, including concurrency, retry, and dead-letter queue (DLQ) settings. [[1]](diffhunk://#diff-dd7e69cdfde6e043d6101726230a6885d017e3251cc529744603ec9a0e0ff344R54-R64) [[2]](diffhunk://#diff-ebb354509092116b7640c8ef729e8a63d09d21b997aca9bfc81d91bbd1d8e2f9R5-R19) [[3]](diffhunk://#diff-ebb354509092116b7640c8ef729e8a63d09d21b997aca9bfc81d91bbd1d8e2f9R62-R73)
* Introduced the `MemoryIndexTask` model class in both the Wiki and Memory services to standardize task payloads. [[1]](diffhunk://#diff-5e29980b9b4508d75b603cc64457da54caa2bb5652e31864b89b8e59782e74b8R1-R136) [[2]](diffhunk://#diff-75b7a23d1403f299c4fd875b9b1f647da5ddd0c0b519a737e759c5beb1f038b9R1-R53)

**Memory Service Enhancements**

* Implemented `KafkaConfig` to configure Kafka consumers for `MemoryIndexTask`, supporting manual acknowledgment, concurrency control, and JSON deserialization.
* Added `MemoryIndexConsumer` to process indexing tasks from Kafka, with validation, retry, and DLQ logic for robust error handling.
* Created `MemoryIndexProducer` to send failed tasks to retry or DLQ topics, including logic for building unique message keys.

**Wiki Service Enhancements**

* Updated Kafka configuration to support producing `MemoryIndexTask` messages, including new `ProducerFactory` and `KafkaTemplate` beans. [[1]](diffhunk://#diff-9f9a97cf5fea7c1e5798f95f4fc90dcb8b61454fad0b81af2353551cdbd66dc8R4) [[2]](diffhunk://#diff-9f9a97cf5fea7c1e5798f95f4fc90dcb8b61454fad0b81af2353551cdbd66dc8R70-R96)

**Python Environment**

* Added `langchain_neo4j` and `rank_bm25` to the Python requirements for potential future enhancements (unrelated to Kafka integration).